### PR TITLE
add support for "COMMENT" in heading line

### DIFF
--- a/org-numbering.el
+++ b/org-numbering.el
@@ -337,7 +337,8 @@ MIN-LEVEL specifies the minimum heading level"
                    (title (org-get-heading t t t t))
                    (components (org-heading-components)))
               (message "DEBUG: Including heading - point=%d level=%d parent=%d title='%s'"
-                      current-point level parent-point title)
+                       current-point level parent-point title)
+              (unless (string-match-p "^COMMENT "(nth 4 (org-heading-components)))
               ;; update parent title record
               (puthash level current-point current-parents)
               ;; clear records of deeper levels
@@ -364,7 +365,7 @@ MIN-LEVEL specifies the minimum heading level"
                                        :parents parent-chain
                                        :todo (nth 2 components)
                                        :priority (nth 3 components)
-                                       :tags (nth 5 components)))))))))))
+                                       :tags (nth 5 components))))))))))))
     (message "DEBUG: Final collected headings: %S" headings)
     headings))
 


### PR DESCRIPTION
ref: https://orgmode.org/manual/Comment-Lines.html

现在只能将文本内容由COMMENT开始的当前行排除记数，但也应该够用了。

```
*** COMMENT 11

**** 1. 123

**** 2. 1123
```